### PR TITLE
Add compaction API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,5 +7,5 @@ group :development do
 end
 
 group :test do
-  gem 'rspec'
+  gem 'rspec', '~> 2.99'
 end

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ puts db.get('foo') # => 'baz'
 
 # compactions
 db.compact_range(from: 'foo', to: 'foo08')
+db.full_compaction
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -36,9 +36,7 @@ puts snapshot.get('foo') # => 'bar'
 puts db.get('foo') # => 'baz'
 
 # compactions
-db.suspend_compactions
 db.compact_range(from: 'foo', to: 'foo08')
-db.resume_compactions
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ snapshot = db.snapshot
 db.put('foo', 'baz')
 puts snapshot.get('foo') # => 'bar'
 puts db.get('foo') # => 'baz'
+
+# compactions
+db.suspend_compactions
+db.compact_range(from: 'foo', to: 'foo08')
+db.resume_compactions
 ```
 
 ## Contributing

--- a/lib/level_db.rb
+++ b/lib/level_db.rb
@@ -114,14 +114,6 @@ module LevelDb
       Snapshot.new(@db)
     end
 
-    def suspend_compactions
-      @db.suspend_compactions
-    end
-
-    def resume_compactions
-      @db.resume_compactions
-    end
-
     def compact_range(options={})
       from = options[:from]
       to = options[:to]

--- a/lib/level_db.rb
+++ b/lib/level_db.rb
@@ -113,6 +113,14 @@ module LevelDb
     def snapshot
       Snapshot.new(@db)
     end
+
+    def suspend_compactions
+      @db.suspend_compactions
+    end
+
+    def resume_compactions
+      @db.resume_compactions
+    end
   end
 
   module LazyEnumerable

--- a/lib/level_db.rb
+++ b/lib/level_db.rb
@@ -119,6 +119,18 @@ module LevelDb
       to = options[:to]
       @db.compact_range(encode_key(from), encode_key(to))
     end
+
+    def full_compaction
+      sstables = @db.get_property(SSTABLES_PROPERTY)
+      pre_compaction_sstables = nil
+      until pre_compaction_sstables == sstables
+        pre_compaction_sstables = sstables
+        compact_range
+        sstables = @db.get_property(SSTABLES_PROPERTY)
+      end
+    end
+
+    SSTABLES_PROPERTY = 'leveldb.sstables'.freeze
   end
 
   module LazyEnumerable

--- a/lib/level_db.rb
+++ b/lib/level_db.rb
@@ -121,6 +121,12 @@ module LevelDb
     def resume_compactions
       @db.resume_compactions
     end
+
+    def compact_range(options={})
+      from = options[:from]
+      to = options[:to]
+      @db.compact_range(encode_key(from), encode_key(to))
+    end
   end
 
   module LazyEnumerable

--- a/spec/level_db_spec.rb
+++ b/spec/level_db_spec.rb
@@ -83,6 +83,32 @@ describe LevelDb do
       end
     end
 
+    describe '#compact_range' do
+      let :leveldb do
+        double(:db, compact_range: nil)
+      end
+
+      it 'compacts the given range' do
+        LevelDb::Db.new(leveldb).compact_range(from: 'one', to: 'three')
+        leveldb.should have_received(:compact_range).with('one'.to_java_bytes, 'three'.to_java_bytes)
+      end
+
+      it "is ok to omit the 'from' option" do
+        LevelDb::Db.new(leveldb).compact_range(to: 'three')
+        leveldb.should have_received(:compact_range).with(nil, 'three'.to_java_bytes)
+      end
+
+      it "is ok to omit the 'to' option" do
+        LevelDb::Db.new(leveldb).compact_range(from: 'one')
+        leveldb.should have_received(:compact_range).with('one'.to_java_bytes, nil)
+      end
+
+      it "is ok to omit all options" do
+        LevelDb::Db.new(leveldb).compact_range
+        leveldb.should have_received(:compact_range).with(nil, nil)
+      end
+    end
+
     describe '#close' do
       it 'closes the database' do
         db = double(:db)

--- a/spec/level_db_spec.rb
+++ b/spec/level_db_spec.rb
@@ -99,6 +99,28 @@ describe LevelDb do
       end
     end
 
+    describe '#full_compaction' do
+      let :sstables do
+        %W[a\nb\nc\nd a\nc a a]
+      end
+
+      let :leveldb do
+        leveldb = double(:db)
+        leveldb.stub(:compact_range)
+        leveldb.stub(:get_property) do |property|
+          if property == 'leveldb.sstables'
+            sstables.shift
+          end
+        end
+        leveldb
+      end
+
+      it 'compacts until there are no changes in the sstables' do
+        LevelDb::Db.new(leveldb).full_compaction
+        leveldb.should have_received(:compact_range).with(nil, nil).exactly(3).times
+      end
+    end
+
     describe '#close' do
       it 'closes the database' do
         db = double(:db)

--- a/spec/level_db_spec.rb
+++ b/spec/level_db_spec.rb
@@ -65,24 +65,6 @@ describe LevelDb do
       db.close
     end
 
-    describe '#suspend_compactions' do
-      it 'suspends compactions' do
-        db = double(:db)
-        db.stub(:suspend_compactions)
-        LevelDb::Db.new(db).suspend_compactions
-        db.should have_received(:suspend_compactions)
-      end
-    end
-
-    describe '#resume_compactions' do
-      it 'resumes compactions' do
-        db = double(:db)
-        db.stub(:resume_compactions)
-        LevelDb::Db.new(db).resume_compactions
-        db.should have_received(:resume_compactions)
-      end
-    end
-
     describe '#compact_range' do
       let :leveldb do
         leveldb = double(:db)

--- a/spec/level_db_spec.rb
+++ b/spec/level_db_spec.rb
@@ -83,17 +83,17 @@ describe LevelDb do
         calls.should include(['one', 'three'])
       end
 
-      it "compacts the whole range to the 'to' key when the 'from' option is omitted" do
+      it 'compacts the whole range to the "to" key when the "from" option is omitted' do
         LevelDb::Db.new(leveldb).compact_range(to: 'three')
         calls.should include([nil, 'three'])
       end
 
-      it "compacts the whole range from the 'from' key when the 'to' option is omitted" do
+      it 'compacts the whole range from the "from" key when the "to" option is omitted' do
         LevelDb::Db.new(leveldb).compact_range(from: 'one')
         calls.should include(['one', nil])
       end
 
-      it "compacts the whole range when the both the 'from' and 'to' options are omitted" do
+      it 'compacts the whole range when the both the "from" and "to" options are omitted' do
         LevelDb::Db.new(leveldb).compact_range
         calls.should include([nil, nil])
       end

--- a/spec/level_db_spec.rb
+++ b/spec/level_db_spec.rb
@@ -65,6 +65,24 @@ describe LevelDb do
       db.close
     end
 
+    describe '#suspend_compactions' do
+      it 'suspends compactions' do
+        db = double(:db)
+        db.stub(:suspend_compactions)
+        LevelDb::Db.new(db).suspend_compactions
+        db.should have_received(:suspend_compactions)
+      end
+    end
+
+    describe '#resume_compactions' do
+      it 'resumes compactions' do
+        db = double(:db)
+        db.stub(:resume_compactions)
+        LevelDb::Db.new(db).resume_compactions
+        db.should have_received(:resume_compactions)
+      end
+    end
+
     describe '#close' do
       it 'closes the database' do
         db = double(:db)


### PR DESCRIPTION
This PR suggests adding methods from the compactions API. Specifically, `#compact_range` which forces an immediate compaction, optionally of a specific range, and `#full_compaction` which will compact the whole range until there are no changes in any sstables.

For some reason `#compact_range` doesn't do a "full" compaction, and subsequent calls might compact further, why I've added the `#full_compaction` helper. It compares the value of the `leveldb.sstables` property from before and after a compaction, and reruns when necessary. According to a comment in the source code, the property holds "a multi-line string that describes all of the sstables that make up the db contents", so the comparison is a bit heavy if the number of sstables is large. But then a compaction is as well.

I've also locked RSpec to `~> 2.99` as some tests use syntax that isn't supported in newer versions of RSpec.

EDIT: Removed `#suspend_compactions` and `#resume_compactions` and added `#full_compaction`
